### PR TITLE
Lock the version of non-English string resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2023-01-29
+### Fixed
+- Hard-code the version of WinGet non-EN-US localization resources to work around microsoft/winget-cli#2783
+
 ## [0.3.2] - 2023-01-21
 ### Fixed
 - Package version information for packages with long names correctly displayed in non-UTF-8 encoded output terminals

--- a/src/Cobalt.ps1
+++ b/src/Cobalt.ps1
@@ -21,7 +21,7 @@ $i18nHandlerHelper = {
 
         $(try {
             # We have to trim the leading BOM for .NET's XML parser to correctly read Microsoft's own files - go figure
-            ([xml](((Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/winget-cli/master/Localization/Resources/$language/winget.resw" -ErrorAction Stop ).Content -replace "\uFEFF", ""))).root.data
+            ([xml](((Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/winget-cli/v1.3.2691/Localization/Resources/$language/winget.resw" -ErrorAction Stop ).Content -replace "\uFEFF", ""))).root.data
         } catch {
             # Fall back to English if a locale file doesn't exist
             (

--- a/src/Cobalt.psd1
+++ b/src/Cobalt.psd1
@@ -1,6 +1,6 @@
 @{
 	RootModule = 'Cobalt.psm1'
-	ModuleVersion = '0.3.2'
+	ModuleVersion = '0.3.3'
 	GUID = '9f295092-e7fd-4c52-b41e-3c5b0612fa52'
 	Author = 'Ethan Bergstrom'
 	Copyright = '2021'


### PR DESCRIPTION
This approach could very easily break as much as it fixes, but with a Microsoft-owned powershell module in the works, and with parsing the output from winget-cli as difficult as it is, I'm not inclined to put much work into fixing this. 